### PR TITLE
fix: remove duplicated module declaration

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -18,7 +18,6 @@ export default defineNuxtConfig({
     '@pinia/nuxt',
     '@nuxt/icon',
     '@nuxtjs/google-fonts',
-    '@nuxtjs/color-mode',
   ],
   content: {
     database: {


### PR DESCRIPTION
I was exploring the project and noticed that `@nuxtjs/color-mode` was declared twice in `nuxt.config.ts`.

I had never done a PR before, so I thought it would be a good time to try.